### PR TITLE
Fixed : get_globalWeight possible error

### DIFF
--- a/src/textClust_C.cpp
+++ b/src/textClust_C.cpp
@@ -322,22 +322,21 @@ public:
   }
 
 
-  Rcpp::List get_globalWeight(std::string token){
+Rcpp::List get_globalWeight(std::string token){
     Rcpp::List result;
-
+    double sum = 0;   
     for(unsigned int i=0; i<this->micro.size(); i++){
       MicroCluster tmp = *(this->micro[i]);
       std::unordered_map<std::string, double> tf = tmp.tf;
-
-      double sum = 0;
 
       // check if token already exists
       std::unordered_map<std::string, double>::iterator it = tf.find(token);
       if(it != tf.end()){
         sum += it->second;
       }
-      result[token] = sum;
+      
     }
+    result[token] = sum;
     return(result);
   }
 


### PR DESCRIPTION
Hi. Going through your code, Noticed with your   _get_globalWeight_ function.
According to your function name, it should return the sum of the weights of a token in all 
microClusters, but as your code suggests it will only return the weight of that token in the last microCluster in which the token was found. 


Here is your code:
 ```
Rcpp::List get_globalWeight(std::string token){
    Rcpp::List result;

    for(unsigned int i=0; i<this->micro.size(); i++){
      MicroCluster tmp = *(this->micro[i]);
      std::unordered_map<std::string, double> tf = tmp.tf;

      double sum = 0;   // Possible Error 

      // check if token already exists
      std::unordered_map<std::string, double>::iterator it = tf.find(token);
      if(it != tf.end()){
        sum += it->second;
      }
      result[token] = sum;
    }
    return(result);
  }
```
I think it should be like this:
 ```
Rcpp::List get_globalWeight(std::string token){
    Rcpp::List result;
    double sum = 0;   
    for(unsigned int i=0; i<this->micro.size(); i++){
      MicroCluster tmp = *(this->micro[i]);
      std::unordered_map<std::string, double> tf = tmp.tf;

      // check if token already exists
      std::unordered_map<std::string, double>::iterator it = tf.find(token);
      if(it != tf.end()){
        sum += it->second;
      }
      
    }
    result[token] = sum;
    return(result);
  }
```

Changes :